### PR TITLE
Fix regex trailing characters.

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -256,7 +256,7 @@ module.exports = grammar({
     integer: $ => choice(/([1-9]\d*|0[0-7]*)[UuLl]?/, /0[xX][A-Fa-f0-9]+/),
     null: $ => 'null',
     real: $ => /\d+(\.\d+)?([eE][+-]?\d+)?[Ff]?/,
-    regex: $ => /\/([^\\\/\n]|\\[\\\/A-z0|\[\]^$?.(){}+\-*])+\/[gmxsu]*/,
+    regex: $ => /\/([^\\\/\n]|\\[\\\/A-z0|\[\]^$?.(){}+\-*])+\/[imsx]*/,
     string: $ => seq(
       '"',
       repeat(choice(


### PR DESCRIPTION
Source:
https://docs.vala.dev/tutorials/programming-language/main/05-00-experimental-features/05-02-regular-expression-literals.html